### PR TITLE
Check IP range for local CIDR and check external IP

### DIFF
--- a/src/app/main.go
+++ b/src/app/main.go
@@ -8,12 +8,49 @@ import (
 	"app/gcloud"
 	"app/ip"
 	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
 	"github.com/davecgh/go-spew/spew"
 	"log"
 	"os"
 	"strings"
 	"time"
 )
+
+var privateIPBlocks []*net.IPNet
+
+func init() {
+    for _, cidr := range []string{
+	        "127.0.0.0/8",    // IPv4 loopback
+	        "10.0.0.0/8",     // RFC1918
+	        "172.16.0.0/12",  // RFC1918
+	        "192.168.0.0/16", // RFC1918
+	        "169.254.0.0/16", // RFC3927 link-local
+	        "::1/128",        // IPv6 loopback
+	        "fe80::/10",      // IPv6 link-local
+	        "fc00::/7",       // IPv6 unique local addr
+    } {
+       _, block, err := net.ParseCIDR(cidr)
+       if err != nil {
+            panic(fmt.Errorf("parse error on %q: %v", cidr, err))
+       }
+       privateIPBlocks = append(privateIPBlocks, block)
+    }
+}
+
+func isPrivateIP(ip net.IP) bool {
+    if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+	        return true
+    }
+
+    for _, block := range privateIPBlocks {
+        if block.Contains(ip) {
+            return true
+        }
+    }
+    return false
+}
 
 func main() {
 	command := "help"
@@ -144,6 +181,21 @@ func readCurrentIP() string {
 	if err != nil {
 		log.Fatal("Failed to read current IP: ", err)
 	}
+
+	if isPrivateIP(net.ParseIP(currentIP)) {
+		//get IP from external source
+		resp, err := http.Get("https://ifconfig.me/ip")
+		if err != nil {
+			log.Fatal("Failed to issue http.Get request to https://ifconfig.me/ip: ", err)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal("Error reading response from https://ifconfig.me/ip: ", err)
+		}
+		currentIP = string(body)
+		defer resp.Body.Close()
+	}
+
 	return currentIP
 }
 


### PR DESCRIPTION
Check if the retrieved interface IP is a local range (such as when a system is behind a router and cannot see the external IP directly from eth0, etc.) and if so, try to use an external service (in this case ifconfig.me/ip) to check the real IP.